### PR TITLE
Fix (golangci) linter messages 

### DIFF
--- a/albums/request_options.go
+++ b/albums/request_options.go
@@ -31,7 +31,7 @@ type Location struct {
 
 type NewEnrichmentItem struct {
 	TextEnrichment     TextEnrichment     `json:"textEnrichment,omitempty"`
-	LocationEnrichment LocationEnrichment `json:"locationEnrichment, omitempty"`
+	LocationEnrichment LocationEnrichment `json:"locationEnrichment,omitempty"`
 	MapEnrichment      MapEnrichment      `json:"mapEnrichment,omitempty"`
 }
 

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -29,7 +29,7 @@ func (c *HttpClient) FetchWithGet(path string, queryValues interface{}, response
 	if reqCb != nil {
 		reqCb(req)
 	}
-	return c.fetchRequest(err, req, responseModel)
+	return c.fetchRequest(req, responseModel)
 }
 
 func (c *HttpClient) PostJSON(path string, queryValues interface{}, body interface{}, responseModel interface{}, reqCb func(req *http.Request), ctx context.Context) error {
@@ -48,7 +48,7 @@ func (c *HttpClient) PostFile(path string, queryValues interface{}, file io.Read
 	if reqCb != nil {
 		reqCb(req)
 	}
-	return c.fetchRequest(err, req, responseModel)
+	return c.fetchRequest(req, responseModel)
 }
 
 func (c *HttpClient) doJSONRequest(path string, queryValues interface{}, body interface{}, method string, responseModel interface{}, reqCb func(req *http.Request), ctx context.Context) error {
@@ -59,10 +59,10 @@ func (c *HttpClient) doJSONRequest(path string, queryValues interface{}, body in
 	if reqCb != nil {
 		reqCb(req)
 	}
-	return c.fetchRequest(err, req, responseModel)
+	return c.fetchRequest(req, responseModel)
 }
 
-func (c *HttpClient) fetchRequest(err error, req *http.Request, responseModel interface{}) error {
+func (c *HttpClient) fetchRequest(req *http.Request, responseModel interface{}) error {
 	res, err := c.c.Do(req)
 	if err != nil {
 		return fmt.Errorf("cannot fetch response: %w", err)

--- a/media_items/request_options.go
+++ b/media_items/request_options.go
@@ -8,15 +8,15 @@ type ListOptions struct {
 
 type SearchOptions struct {
 	PageSize int            `json:"pageSize"`
-	AlbumId  string         `json:"albumId,omitEmpty"`
-	Filters  *SearchFilters `json:"filters,omitEmpty"`
+	AlbumId  string         `json:"albumId,omitempty"`
+	Filters  *SearchFilters `json:"filters,omitempty"`
 }
 
 type SearchFilters struct {
-	FeatureFilter            *FeatureFilter   `json:"featureFilter,omitEmpty"`
-	DateFilter               *DateFilter      `json:"dateFilter, omitEmpty"`
-	ContentFilter            *ContentFilter   `json:"contentFilter, omitEmpty"`
-	MediaTypeFilter          *MediaTypeFilter `json:"mediaTypeFilter, omitEmpty"`
+	FeatureFilter            *FeatureFilter   `json:"featureFilter,omitempty"`
+	DateFilter               *DateFilter      `json:"dateFilter,omitempty"`
+	ContentFilter            *ContentFilter   `json:"contentFilter,omitempty"`
+	MediaTypeFilter          *MediaTypeFilter `json:"mediaTypeFilter,omitempty"`
 	IncludeArchivedMedia     bool             `json:"includeArchivedMedia"`
 	ExcludeNonAppCreatedData bool             `json:"excludeNonAppCreatedData"`
 }
@@ -47,7 +47,7 @@ type DateFilterRangeItem struct {
 }
 
 type FeatureFilter struct {
-	IncludedFeatures []Feature `json:"includedFeatures,omitEmpty"`
+	IncludedFeatures []Feature `json:"includedFeatures,omitempty"`
 }
 
 type BatchCreateOptions struct {

--- a/media_items/service.go
+++ b/media_items/service.go
@@ -190,7 +190,7 @@ func (s HttpMediaItemsService) List(options *ListOptions, pageToken string, ctx 
 	}
 	optionsWithToken := struct {
 		ListOptions
-		PageToken string `url:"pageToken,omitEmpty"`
+		PageToken string `url:"pageToken,omitempty"`
 	}{
 		requestOptions,
 		pageToken,
@@ -266,7 +266,7 @@ func (s HttpMediaItemsService) Search(options *SearchOptions, pageToken string, 
 	responseModel := &mediaItemsResponse{}
 	optionsWithToken := struct {
 		SearchOptions
-		PageToken string `json:"pageToken,omitEmpty"`
+		PageToken string `json:"pageToken,omitempty"`
 	}{
 		requestOptions,
 		pageToken,

--- a/shared_albums/service.go
+++ b/shared_albums/service.go
@@ -78,7 +78,7 @@ func (s HttpSharedAlbumsService) List(options *ListOptions, pageToken string, ct
 	}
 	optionsWithToken := struct {
 		ListOptions
-		PageToken string `url:"pageToken,omitEmpty"`
+		PageToken string `url:"pageToken,omitempty"`
 	}{
 		requestOptions,
 		pageToken,


### PR DESCRIPTION
I've used [golangci](https://github.com/golangci/golangci-lint) to lint the code and I've addressed all linter messages

- Incompatible JSON tags: mainly changing `omitEmpty` for `omitempty`
- Function signature `fetchRequest()` had a `err` parameter that was not used inside the function. I've removed it to simplify it.

If this second change is not correct, please let me know why you wanted to pass the `err` to that function. 